### PR TITLE
feat: #44 Add --destination and --rules options to rule command

### DIFF
--- a/tests/cli/test_rule_commands_apply_changelog.py
+++ b/tests/cli/test_rule_commands_apply_changelog.py
@@ -18,7 +18,7 @@ def test_rule_apply_writes_apply_entries_to_changelog(
     )
 
     # Make CLI use our rules file
-    monkeypatch.setattr(rc, "_find_rules_file", lambda: rules_path)
+    monkeypatch.setattr(rc, "_find_rules_file", lambda *args, **kwargs: rules_path)
 
     # Use real RuleLoader to parse YAML
     from src.rules.loader import RuleLoader as RealRuleLoader

--- a/tests/cli/test_rule_commands_non_dry.py
+++ b/tests/cli/test_rule_commands_non_dry.py
@@ -16,7 +16,7 @@ def test_rule_apply_command_non_dry(monkeypatch, tmp_path):
     )
 
     # Provide _find_rules_file to return our file
-    monkeypatch.setattr(rc, "_find_rules_file", lambda: rules_path)
+    monkeypatch.setattr(rc, "_find_rules_file", lambda *args, **kwargs: rules_path)
 
     # Real loader to parse YAML
     from src.rules.loader import RuleLoader as RealRuleLoader

--- a/tests/cli/test_rule_commands_unit.py
+++ b/tests/cli/test_rule_commands_unit.py
@@ -91,7 +91,7 @@ def test_rule_remove_command_marks_disabled(tmp_path, monkeypatch):
     )
 
     # Ensure _find_rules_file returns this file
-    monkeypatch.setattr(rc, "_find_rules_file", lambda: rules_path)
+    monkeypatch.setattr(rc, "_find_rules_file", lambda *args, **kwargs: rules_path)
 
     rc.rule_remove_command(3)
     data = yaml.safe_load(rules_path.read_text())
@@ -118,7 +118,7 @@ def test_rule_apply_command_dry_run_path(monkeypatch, tmp_path, capsys):
 
     real_loader = RealRuleLoader()
     monkeypatch.setattr(rc, "RuleLoader", lambda: real_loader)
-    monkeypatch.setattr(rc, "_find_rules_file", lambda: rules_path)
+    monkeypatch.setattr(rc, "_find_rules_file", lambda *args, **kwargs: rules_path)
 
     # Fake client with get_categories and get_transaction
     class DummyClient:


### PR DESCRIPTION
## Summary

Adds support for --destination and --rules options to the rule command to provide the same semantics as other pull and push commands.

## Changes Made

- **Added --destination option**: Works with both file and directory paths, derives rules file location from destination when specified
- **Added --rules option**: Accepts either a single rule file or directory path. When given a directory, uses rules.yaml in that directory
- **Enhanced _find_rules_file()**: Handles new option precedence: --rules > --destination > default
- **Directory creation**: Automatically creates parent directories when needed for new rules files
- **Type safety**: Fixed type annotations to use Optional[Path] for mypy compliance  
- **Test compatibility**: Updated test mocks to handle new _find_rules_file signature

## Option Precedence

1. If --rules is specified → use that file/directory
2. If --destination is specified → derive rules file from destination  
3. Otherwise → use default behavior

## Examples

```bash
# Use specific rules file
peabody rule --rules /path/to/rules.yaml add --if merchant=starbucks --then category=Dining

# Use rules.yaml in directory (creates if needed)  
peabody rule --rules /path/to/directory add --if merchant=amazon --then category=Shopping

# Use destination-derived rules file
peabody rule --destination /path/to/ledger.beancount add --if merchant=mcdonalds --then category="Fast Food"

# Rules option takes precedence over destination
peabody rule --destination ledger --rules rules_dir add --if merchant=walmart --then category=Groceries
```

## Testing

- [x] All existing tests pass
- [x] Pre-commit hooks pass (ruff, mypy, pytest, bean-check)
- [x] Manually tested new functionality
- [x] Maintains backward compatibility

Closes #44