### PR TITLE
feat: #46 Enhance rule apply command to support batch processing

### DIFF
--- a/.claude/commands/vibe-commit.md
+++ b/.claude/commands/vibe-commit.md
@@ -1,0 +1,25 @@
+This is the procedure for commiting and submitting code changes. Read each step
+carefully, and follow them one by one, not skipping any steps.
+
+  1. Run all precommit checks using `uv run pre-commit`. Fix any problems you find
+  2. Study the current session context and code changes to understand what code
+     is being committed, and why
+  3. Create a GitHub issue with the summary from Step 1. Note down its issue
+     number
+  4. Create and switch to a branch that is named after the summary from Step 1
+  5. Generate a commit message with the following conventional format:
+
+    - **First line**: `<type>: #[ISSUE_NUMBER] [SUMMARY]`
+      - `<type>` follows [Conventional
+        Commits](https://www.conventionalcommits.org) (feat, fix, docs, etc.)
+      - `[ISSUE_NUMBER]` is the GitHub issue number (e.g., #17)
+      - `[SUMMARY]` is a concise one-line description
+    - **Body**: Summary from step 1
+    - **Final line**: `Closes #[ISSUE_NUMBER]`
+
+  6. Create a GitHub Pull Request for this branch. Wait for the PR checks to
+     complete
+  7. If PR checks are successful, rebase merge the branch. Switch back to
+     master and pull the latest changes. Clean up the old branch. If PR checks
+     failed, fix them
+

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ wheels/
 
 # Generated output files
 output/
+.ledger/
+ledger.beancount
 
 # Hypothesis cache
 .hypothesis/

--- a/main.py
+++ b/main.py
@@ -440,13 +440,22 @@ def rule_remove(
 @rule_app.command("apply")
 def rule_apply(
     ctx: typer.Context,
-    rule_id: int = typer.Argument(..., help="Rule ID to apply"),
-    transaction_id: str = typer.Argument(..., help="Transaction ID to apply rule to"),
+    rule_id: Optional[int] = typer.Argument(
+        None, help="Rule ID to apply (if not provided, all rules are eligible)"
+    ),
+    transaction_id: Optional[str] = typer.Argument(
+        None,
+        help="Transaction ID to apply rule to (if not provided, all transactions are processed)",
+    ),
     dry_run: bool = typer.Option(
         False, "-n", "--dry-run", help="Preview changes without applying them"
     ),
 ) -> None:
-    """Apply a specific rule to a specific transaction."""
+    """Apply rules to transactions.
+
+    If rule_id is not provided, all rules will be eligible for evaluation.
+    If transaction_id is not provided, all transactions will be matched against eligible rules.
+    """
     from src.cli.rule_commands import rule_apply_command
 
     # Get destination and rules from parent context

--- a/tests/cli/test_rule_commands_unit.py
+++ b/tests/cli/test_rule_commands_unit.py
@@ -133,4 +133,5 @@ def test_rule_apply_command_dry_run_path(monkeypatch, tmp_path, capsys):
     # Run dry run
     rc.rule_apply_command(5, "123", dry_run=True)
     out = capsys.readouterr().out
-    assert "Dry run - would apply rule 5" in out
+    assert "Would apply rule 5 to transaction 123" in out
+    assert "Dry run completed:" in out


### PR DESCRIPTION
## Summary

Enhances the rule apply command to support batch processing by making both `rule_id` and `transaction_id` optional parameters. This enables powerful workflow scenarios where users can apply all rules to all transactions, or specific rules to all transactions, significantly improving productivity.

## Changes Made

- **Optional Parameters**: Made `rule_id` and `transaction_id` optional in rule apply command
- **Batch Rule Processing**: When `rule_id` is omitted, all rules are eligible for evaluation
- **Batch Transaction Processing**: When `transaction_id` is omitted, all transactions are processed (from last sync or last 30 days)
- **Directory Support**: Added support for directory-based rules loading in add/remove commands
- **Enhanced Feedback**: Improved error handling and user feedback with processing summaries
- **Housekeeping**: Updated .gitignore to exclude temporary ledger files
- **Test Updates**: Fixed test assertions to match new output format

## Benefits

- Enables bulk rule application workflows for improved productivity
- Maintains full backward compatibility with existing specific rule-transaction usage
- Provides clear feedback on batch processing results with match and application counts
- Supports flexible rule management with directory-based loading

## Testing

- All existing tests pass
- New test assertions verify the enhanced output format
- Pre-commit hooks (ruff, mypy, pytest, bean-check) all pass

## Related Issue

Closes #46

## Test Plan

- [ ] Verify backward compatibility: existing `rule apply <rule_id> <transaction_id>` commands work unchanged
- [ ] Test batch scenarios: `rule apply` (all rules, all transactions)
- [ ] Test partial batch: `rule apply <rule_id>` (specific rule, all transactions)
- [ ] Test partial batch: `rule apply -- <transaction_id>` (all rules, specific transaction)
- [ ] Verify error handling and user feedback messages
- [ ] Confirm directory-based rules loading in add/remove commands