### PR TITLE
Rename --destination to --ledger and add environment variable support

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,7 +8,11 @@ from src.cli.clone import clone_command
 from src.cli.pull import pull_command
 from src.cli.diff import diff_command
 from src.cli.push import push_command
-from src.cli.common import handle_default_destination, transaction_id_option
+from src.cli.common import (
+    handle_default_ledger,
+    resolve_config_path,
+    transaction_id_option,
+)
 from src.cli.date_options import DateOptions
 
 # Create the main typer app
@@ -38,7 +42,7 @@ def help() -> None:
 
 @app.command()
 def clone(
-    destination: Optional[Path] = typer.Argument(
+    ledger: Optional[Path] = typer.Argument(
         None,
         help="Output file or directory path (defaults to current directory's beancount file)",
     ),
@@ -94,11 +98,13 @@ def clone(
     files in yearly subdirectories. Use -1/--single-file to write everything
     to a single file.
 
-    The destination must not exist and must be in a writable location.
-    If no destination is provided, attempts to find a default beancount file
+    The ledger must not exist and must be in a writable location.
+    If no ledger is provided, attempts to find a default beancount file
     in the current directory.
     """
-    destination = handle_default_destination(destination)
+    ledger_path, ledger_source = handle_default_ledger(ledger)
+    if not quiet:
+        typer.echo(f"Using ledger: {ledger_path} (from {ledger_source})")
 
     date_options = DateOptions(
         from_date=from_date,
@@ -110,7 +116,7 @@ def clone(
     )
 
     clone_command(
-        destination=destination,
+        destination=ledger_path,
         single_file=single_file,
         date_options=date_options,
         quiet=quiet,
@@ -119,7 +125,7 @@ def clone(
 
 @app.command()
 def pull(
-    destination: Optional[Path] = typer.Argument(
+    ledger: Optional[Path] = typer.Argument(
         None,
         help="File or directory to update (defaults to current directory's beancount file)",
     ),
@@ -181,10 +187,12 @@ def pull(
     If date options are provided, triggers a second fetch operation with the new
     date ranges.
 
-    If no destination is provided, attempts to find a default beancount file
+    If no ledger is provided, attempts to find a default beancount file
     in the current directory.
     """
-    destination = handle_default_destination(destination)
+    ledger_path, ledger_source = handle_default_ledger(ledger)
+    if not quiet:
+        typer.echo(f"Using ledger: {ledger_path} (from {ledger_source})")
 
     date_options = DateOptions(
         from_date=from_date,
@@ -196,7 +204,7 @@ def pull(
     )
 
     pull_command(
-        destination=destination,
+        destination=ledger_path,
         verbose=verbose,
         date_options=date_options,
         dry_run=dry_run,
@@ -207,7 +215,7 @@ def pull(
 
 @app.command()
 def diff(
-    destination: Optional[Path] = typer.Argument(
+    ledger: Optional[Path] = typer.Argument(
         None,
         help="File or directory to compare (defaults to current directory's beancount file)",
     ),
@@ -262,10 +270,11 @@ def diff(
 
     Never modifies the local ledger, changelog, or remote data.
 
-    If no destination is provided, attempts to find a default beancount file
+    If no ledger is provided, attempts to find a default beancount file
     in the current directory.
     """
-    destination = handle_default_destination(destination)
+    ledger_path, ledger_source = handle_default_ledger(ledger)
+    typer.echo(f"Using ledger: {ledger_path} (from {ledger_source})")
 
     date_options = DateOptions(
         from_date=from_date,
@@ -277,7 +286,7 @@ def diff(
     )
 
     diff_command(
-        destination=destination,
+        destination=ledger_path,
         format=format,
         date_options=date_options,
         transaction_id=transaction_id,
@@ -286,7 +295,7 @@ def diff(
 
 @app.command()
 def push(
-    destination: Optional[Path] = typer.Argument(
+    ledger: Optional[Path] = typer.Argument(
         None,
         help="File or directory to push (defaults to current directory's beancount file)",
     ),
@@ -338,7 +347,9 @@ def push(
     ),
 ) -> None:
     """Upload local changes to PocketSmith."""
-    destination = handle_default_destination(destination)
+    ledger_path, ledger_source = handle_default_ledger(ledger)
+    if not quiet:
+        typer.echo(f"Using ledger: {ledger_path} (from {ledger_source})")
 
     date_options = DateOptions(
         from_date=from_date,
@@ -350,7 +361,7 @@ def push(
     )
 
     push_command(
-        destination=destination,
+        destination=ledger_path,
         dry_run=dry_run,
         verbose=verbose,
         quiet=quiet,
@@ -377,9 +388,9 @@ def rule_main(
     then_params: Optional[List[str]] = typer.Option(
         None, "--then", help="Add transform: key=value"
     ),
-    destination: Optional[Path] = typer.Option(
+    ledger: Optional[Path] = typer.Option(
         None,
-        "--destination",
+        "--ledger",
         help="File or directory to work with (defaults to current directory's beancount file)",
     ),
     rules: Optional[Path] = typer.Option(
@@ -393,10 +404,18 @@ def rule_main(
         # If no subcommand provided, show help
         typer.echo(ctx.get_help())
 
-    # Store the options in context for subcommands to use
+    # Resolve configuration paths with environment variable support
+    ledger_path, ledger_source = handle_default_ledger(ledger)
+    rules_path, rules_source = resolve_config_path(
+        rules, "PEABODY_RULES", ".rules/", "rules"
+    )
+
+    # Store the resolved options in context for subcommands to use
     ctx.ensure_object(dict)
-    ctx.obj["destination"] = destination
-    ctx.obj["rules"] = rules
+    ctx.obj["ledger"] = ledger_path
+    ctx.obj["ledger_source"] = ledger_source
+    ctx.obj["rules"] = rules_path
+    ctx.obj["rules_source"] = rules_source
 
 
 @rule_app.command("add")
@@ -416,11 +435,19 @@ def rule_add(
     """
     from src.cli.rule_commands import rule_add_command
 
-    # Get destination and rules from parent context
-    destination = ctx.obj.get("destination") if ctx.obj else None
+    # Get ledger and rules from parent context
+    ledger = ctx.obj.get("ledger") if ctx.obj else None
+    ledger_source = ctx.obj.get("ledger_source") if ctx.obj else None
     rules = ctx.obj.get("rules") if ctx.obj else None
+    rules_source = ctx.obj.get("rules_source") if ctx.obj else None
 
-    rule_add_command(if_params, then_params, destination, rules)
+    # Show config sources
+    if ledger_source:
+        typer.echo(f"Using ledger: {ledger} (from {ledger_source})")
+    if rules_source:
+        typer.echo(f"Using rules: {rules} (from {rules_source})")
+
+    rule_add_command(if_params, then_params, ledger, rules)
 
 
 @rule_app.command("rm")
@@ -433,6 +460,11 @@ def rule_remove(
 
     # Get rules from parent context
     rules = ctx.obj.get("rules") if ctx.obj else None
+    rules_source = ctx.obj.get("rules_source") if ctx.obj else None
+
+    # Show config source
+    if rules_source:
+        typer.echo(f"Using rules: {rules} (from {rules_source})")
 
     rule_remove_command(rule_id, rules)
 
@@ -458,11 +490,19 @@ def rule_apply(
     """
     from src.cli.rule_commands import rule_apply_command
 
-    # Get destination and rules from parent context
-    destination = ctx.obj.get("destination") if ctx.obj else None
+    # Get ledger and rules from parent context
+    ledger = ctx.obj.get("ledger") if ctx.obj else None
+    ledger_source = ctx.obj.get("ledger_source") if ctx.obj else None
     rules = ctx.obj.get("rules") if ctx.obj else None
+    rules_source = ctx.obj.get("rules_source") if ctx.obj else None
 
-    rule_apply_command(rule_id, transaction_id, dry_run, destination, rules)
+    # Show config sources
+    if ledger_source:
+        typer.echo(f"Using ledger: {ledger} (from {ledger_source})")
+    if rules_source:
+        typer.echo(f"Using rules: {rules} (from {rules_source})")
+
+    rule_apply_command(rule_id, transaction_id, dry_run, ledger, rules)
 
 
 @rule_app.command("list")
@@ -484,6 +524,11 @@ def rule_list(
 
     # Get rules from parent context
     rules = ctx.obj.get("rules") if ctx.obj else None
+    rules_source = ctx.obj.get("rules_source") if ctx.obj else None
+
+    # Show config source
+    if rules_source:
+        typer.echo(f"Using rules: {rules} (from {rules_source})")
 
     rule_list_command(verbose, rule_id, rules)
 
@@ -509,6 +554,11 @@ def rule_lookup(
 
     # Get rules from parent context
     rules = ctx.obj.get("rules") if ctx.obj else None
+    rules_source = ctx.obj.get("rules_source") if ctx.obj else None
+
+    # Show config source
+    if rules_source:
+        typer.echo(f"Using rules: {rules} (from {rules_source})")
 
     rule_lookup_command(merchant, category, account, rules)
 

--- a/src/cli/common.py
+++ b/src/cli/common.py
@@ -1,21 +1,63 @@
 """Common CLI utilities and shared functionality."""
 
+import os
 import typer
 from pathlib import Path
-from typing import Optional, Any
+from typing import Optional, Any, Tuple
 
 from .file_handler import find_default_beancount_file, FileHandlerError
 
 
-def handle_default_destination(destination: Optional[Path]) -> Path:
-    """Handle default destination for commands that operate on beancount files."""
-    if destination is None:
+def resolve_config_path(
+    cli_value: Optional[Path], env_var_name: str, default_value: str, config_type: str
+) -> Tuple[Path, str]:
+    """Resolve configuration path with priority: CLI > env var > default.
+
+    Returns:
+        Tuple of (resolved_path, source_description)
+    """
+    if cli_value is not None:
+        return cli_value, f"CLI argument (--{config_type.lower()})"
+
+    env_value = os.getenv(env_var_name)
+    if env_value:
+        return Path(env_value), f"environment variable {env_var_name}"
+
+    return Path(default_value), f"default ({default_value})"
+
+
+def handle_default_ledger(ledger: Optional[Path]) -> Tuple[Path, str]:
+    """Handle default ledger for commands that operate on beancount files.
+
+    Returns:
+        Tuple of (resolved_path, source_description)
+    """
+    resolved_path, source = resolve_config_path(
+        ledger, "PEABODY_LEDGER", ".ledger/", "ledger"
+    )
+
+    # If using default or env var, try to find actual beancount file
+    if ledger is None:
         try:
-            destination = find_default_beancount_file()
-        except FileHandlerError as e:
-            typer.echo(f"Error: {e}", err=True)
-            raise typer.Exit(1)
-    return destination
+            actual_path = find_default_beancount_file()
+            # Only use the found file if we're using the default value
+            if source.startswith("default"):
+                resolved_path = actual_path
+                source = f"default (found {actual_path})"
+        except FileHandlerError:
+            # Keep the resolved path as is
+            pass
+
+    return resolved_path, source
+
+
+def handle_default_destination(destination: Optional[Path]) -> Path:
+    """Handle default destination for commands that operate on beancount files.
+
+    DEPRECATED: Use handle_default_ledger instead.
+    """
+    ledger_path, _ = handle_default_ledger(destination)
+    return ledger_path
 
 
 def transaction_id_option() -> Any:

--- a/src/cli/rule_commands.py
+++ b/src/cli/rule_commands.py
@@ -19,7 +19,7 @@ from .file_handler import find_default_beancount_file, FileHandlerError
 def rule_add_command(
     if_params: List[str],
     then_params: List[str],
-    destination: Optional[Path] = None,
+    ledger: Optional[Path] = None,
     rules_path: Optional[Path] = None,
 ) -> None:
     """Add a new transaction processing rule."""
@@ -37,7 +37,7 @@ def rule_add_command(
                 rules_file = rules_path
         else:
             # Find rules file using the existing logic
-            rules_file = _find_rules_file(destination, rules_path)
+            rules_file = _find_rules_file(ledger, rules_path)
 
         # Load existing rules to determine next ID
         rule_loader = RuleLoader()
@@ -162,7 +162,7 @@ def rule_apply_command(
     rule_id: Optional[int],
     transaction_id: Optional[str],
     dry_run: bool = False,
-    destination: Optional[Path] = None,
+    ledger: Optional[Path] = None,
     rules_path: Optional[Path] = None,
 ) -> None:
     """Apply rules to transactions.
@@ -179,7 +179,7 @@ def rule_apply_command(
             rules_load_path = rules_path
         else:
             # Find rules file using the existing logic
-            rules_load_path = _find_rules_file(destination, rules_path)
+            rules_load_path = _find_rules_file(ledger, rules_path)
 
         # Load rules
         rule_loader = RuleLoader()
@@ -224,8 +224,8 @@ def rule_apply_command(
         else:
             # Get all transactions - use last sync info or reasonable defaults
             try:
-                if destination:
-                    beancount_file = destination
+                if ledger:
+                    beancount_file = ledger
                 else:
                     beancount_file = find_default_beancount_file()
                 single_file = beancount_file.is_file()
@@ -265,8 +265,8 @@ def rule_apply_command(
 
         changelog: Optional[ChangelogManager] = None
         if not dry_run:
-            if destination:
-                beancount_file = destination
+            if ledger:
+                beancount_file = ledger
             else:
                 beancount_file = find_default_beancount_file()
             single_file = beancount_file.is_file()
@@ -767,7 +767,7 @@ def _parse_rule_ids(rule_id_string: str) -> List[int]:
 
 
 def _find_rules_file(
-    destination: Optional[Path] = None, rules_path: Optional[Path] = None
+    ledger: Optional[Path] = None, rules_path: Optional[Path] = None
 ) -> Path:
     """Find the rules file based on the provided options or current beancount file."""
     if rules_path:
@@ -779,8 +779,8 @@ def _find_rules_file(
             return rules_path
 
     try:
-        if destination:
-            beancount_file = destination
+        if ledger:
+            beancount_file = ledger
         else:
             beancount_file = find_default_beancount_file()
 

--- a/tests/cli/test_cli_clone.py
+++ b/tests/cli/test_cli_clone.py
@@ -453,7 +453,7 @@ class TestCloneCommandHelp:
         assert "Download PocketSmith transactions" in result.stdout
         # The help text mentions the key options in the description
         assert "single" in result.stdout.lower()  # References single file mode
-        assert "DESTINATION" in result.stdout  # Shows the required argument
+        assert "LEDGER" in result.stdout  # Shows the required argument
 
     def test_clone_command_options_present(self):
         """Test that clone command has expected options configured."""
@@ -469,7 +469,7 @@ class TestCloneCommandHelp:
         sig = inspect.signature(main.clone)
         params = list(sig.parameters.keys())
 
-        assert "destination" in params
+        assert "ledger" in params
         assert "single_file" in params
         assert "from_date" in params
         assert "to_date" in params

--- a/tests/cli/test_pull.py
+++ b/tests/cli/test_pull.py
@@ -360,7 +360,7 @@ class TestPullCommandHelp:
         assert result.exit_code == 0
         assert "Update local Beancount ledger" in result.stdout
         assert "updated_since" in result.stdout
-        assert "DESTINATION" in result.stdout
+        assert "LEDGER" in result.stdout
 
     def test_pull_command_options_present(self):
         """Test that pull command has expected options configured."""
@@ -371,7 +371,7 @@ class TestPullCommandHelp:
         sig = inspect.signature(main.pull)
         params = list(sig.parameters.keys())
 
-        assert "destination" in params
+        assert "ledger" in params
         assert "dry_run" in params
         assert "quiet" in params
         assert "from_date" in params


### PR DESCRIPTION
## Summary
- Rename `--destination` argument to `--ledger` across all commands
- Add environment variable support for `PEABODY_RULES` and `PEABODY_LEDGER`
- Implement priority system: CLI argument → Environment variable → Default value
- Add configuration source reporting to show which config source is being used

## Test plan
- [x] All precommit checks pass (ruff, mypy, pytest, bean-check)
- [x] Help text shows new `--ledger` argument instead of `--destination`
- [x] Environment variables work correctly: `PEABODY_RULES=~/rules uv run python main.py rule list`
- [x] CLI arguments override environment variables as expected
- [x] Configuration source is properly reported in output

🤖 Generated with [Claude Code](https://claude.ai/code)