### PR TITLE
Fix pull command to preserve existing monthly includes and account dates

### DIFF
--- a/src/beancount/write.py
+++ b/src/beancount/write.py
@@ -57,8 +57,19 @@ def write_hierarchical_ledger(
     categories: List[Dict[str, Any]],
     output_dir: str,
     account_balances: Optional[Dict[int, List[Dict[str, Any]]]] = None,
+    existing_months: Optional[List[str]] = None,
 ) -> Dict[str, str]:
-    """Write transactions to hierarchical file structure with yearly folders and monthly files."""
+    """Write transactions to hierarchical file structure with yearly folders and monthly files.
+
+    Args:
+        transactions: List of transactions to write
+        transaction_accounts: List of account data
+        categories: List of category data
+        output_dir: Output directory path
+        account_balances: Optional account balances
+        existing_months: Optional list of existing year-month strings (e.g., ["2020-02", "2020-03"])
+                        to preserve in includes even if no new transactions for those months
+    """
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
 
@@ -89,9 +100,14 @@ def write_hierarchical_ledger(
         write_ledger(month_content, str(monthly_file_path))
         written_files[f"{year}/{monthly_filename}"] = str(monthly_file_path)
 
+    # Combine existing months with new months for includes
+    all_months = set(transactions_by_month.keys())
+    if existing_months:
+        all_months.update(existing_months)
+
     # Create top-level main file with declarations and includes
     main_content = generate_main_file_content(
-        list(transactions_by_month.keys()),
+        sorted(list(all_months)),  # Sort to ensure consistent ordering
         transaction_accounts,
         categories,
         account_balances,


### PR DESCRIPTION
## Summary
Fixes a bug where the `pull` command was removing historical monthly transaction includes and resetting expense account opening dates to today's date.

## Problem
When running `pull` after a `clone`:
1. All historical monthly transaction file includes (e.g., `2020/2020-02.beancount` through `2024/2024-12.beancount`) were removed from `main.beancount`
2. Expense account opening dates changed from their historical dates (e.g., `2020-02-01`) to today's date (`2025-11-22`)

This happened because the `pull` command only considered newly fetched transactions when:
- Determining which months to include in `main.beancount`
- Calculating opening dates for expense/income accounts

## Solution
Modified the `pull` command to:
1. Read existing monthly includes from `main.beancount` before regenerating it
2. Pass these existing months to `write_hierarchical_ledger` via a new `existing_months` parameter
3. Combine existing months with new months when generating the main file
4. Use the earliest date (from existing or new months) for account declarations

This ensures `pull` operations are truly incremental and preserve all historical data.

## Testing
Tested by:
1. Running `clone` to create initial ledger with historical data (2020-2025)
2. Immediately running `pull` with no changes
3. Verifying only the timestamp changed in `main.beancount`:
   - ✅ Expense account dates preserved at `2020-02-01`
   - ✅ All monthly includes from 2020-2025 preserved
   - ✅ Git diff shows only 1 line changed (the generation timestamp)

## Files Changed
- `src/cli/pull.py`: Added `read_existing_month_includes()` helper and modified hierarchical write logic
- `src/beancount/write.py`: Added `existing_months` parameter to `write_hierarchical_ledger()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)