### PR TITLE
fix: Set pull date range to last_to_date - 7 days through today

### DIFF
--- a/src/cli/pull.py
+++ b/src/cli/pull.py
@@ -282,9 +282,24 @@ def pull_command(
             end_date_str = end_date.isoformat() if end_date else None
             use_new_dates = True
         else:
-            # Use dates from last sync
-            start_date_str = last_from_date
-            end_date_str = last_to_date
+            # Calculate date range based on last sync
+            # Start from last_to_date - 7 days (to catch any updates)
+            # End at today
+            from datetime import datetime, date
+
+            if last_to_date:
+                # Parse last_to_date and subtract 7 days
+                last_to = datetime.fromisoformat(last_to_date).date()
+                start_date = last_to - timedelta(days=7)
+                start_date_str = start_date.isoformat()
+            else:
+                # If no last_to_date, use last_from_date
+                start_date_str = last_from_date
+
+            # Always use today as end date
+            end_date = date.today()
+            end_date_str = end_date.isoformat()
+            use_new_dates = True
 
         # Connect to PocketSmith API
         if not quiet:


### PR DESCRIPTION
## Summary
- Fixed pull command to automatically extend date range on each pull
- Without date options, pull now fetches from (last_to_date - 7 days) through today
- Previously, pull would reuse the old date range, causing it to stop fetching new transactions

## Problem
When running `pull` without date options, the command was reusing the exact same date range from the last sync (e.g., 2025-11-01 to 2026-01-05). This meant no transactions after January 5th would be fetched, effectively getting stuck in the past.

## Solution
Changed the default date range logic to:
- Start: `last_to_date - 7 days` (to catch any updated transactions in the overlap period)
- End: `today` (always fetch up to the current date)
- Sets `use_new_dates = True` to trigger a full fetch for this range

## Test plan
- [ ] Run `uv run python main.py pull` without date options
- [ ] Verify it fetches transactions from (last_to_date - 7 days) through today
- [ ] Verify changelog is updated with new date range
- [ ] Verify subsequent pulls continue to work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)